### PR TITLE
[TPP-63] Strategy configuration

### DIFF
--- a/android/src/main/kotlin/com/example/nearby_cross/Advertiser.kt
+++ b/android/src/main/kotlin/com/example/nearby_cross/Advertiser.kt
@@ -30,7 +30,8 @@ class Advertiser(
                 // We're discovering! Using service id: $serviceId
                 Log.d(
                     "INFO",
-                    "We're advertising! Using service id: $serviceId and username $userName"
+                    "We're advertising in $strategy mode! Using service id: $serviceId " +
+                            "and username $userName"
                 )
             }
             .addOnFailureListener { e ->

--- a/android/src/main/kotlin/com/example/nearby_cross/Discoverer.kt
+++ b/android/src/main/kotlin/com/example/nearby_cross/Discoverer.kt
@@ -46,7 +46,10 @@ class Discoverer(
             .startDiscovery(this.serviceId, this.endpointDiscoveryCallback, discoveryOptions)
             .addOnSuccessListener {
                 // We're discovering! Using service id: $serviceId
-                Log.d("INFO", "We're discovering! Using service id: $this.serviceId")
+                Log.d(
+                    "INFO", "We're discovering in $strategy! " +
+                            "Using service id: ${this.serviceId}"
+                )
             }
             .addOnFailureListener { e ->
                 // We were unable to start discovery.

--- a/example/lib/screens/main_screen.dart
+++ b/example/lib/screens/main_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:nearby_cross/constants/nearby_strategies.dart';
 import 'package:nearby_cross_example/viewmodels/main_viewmodel.dart';
 import 'package:nearby_cross_example/widgets/discoverer_actions.dart';
 import 'package:nearby_cross_example/widgets/input_dialog.dart';
@@ -44,19 +45,51 @@ class MainScreen extends StatelessWidget {
                               crossAxisAlignment: CrossAxisAlignment.start,
                               mainAxisSize: MainAxisSize.max,
                               children: [
-                                Consumer<MainViewModel>(
-                                  builder: (context, viewModel, child) => Text(
-                                    viewModel.username,
-                                    textAlign: TextAlign.start,
-                                    maxLines: 1,
-                                    overflow: TextOverflow.clip,
-                                    style: const TextStyle(
-                                      fontWeight: FontWeight.w700,
-                                      fontStyle: FontStyle.normal,
-                                      fontSize: 18,
-                                      color: Color(0xff000000),
+                                Row(
+                                  mainAxisAlignment: MainAxisAlignment.start,
+                                  crossAxisAlignment: CrossAxisAlignment.center,
+                                  mainAxisSize: MainAxisSize.max,
+                                  children: [
+                                    Ink(
+                                      decoration: const ShapeDecoration(
+                                        color: Colors.white,
+                                        shape: CircleBorder(),
+                                      ),
+                                      child: Consumer<MainViewModel>(
+                                        builder: (context, viewModel, child) =>
+                                            IconButton(
+                                          icon: const Icon(Icons.edit),
+                                          color: viewModel.advertiserMode
+                                              ? Colors.blue
+                                              : Colors.red,
+                                          onPressed: () => showDialog(
+                                            context: context,
+                                            builder: (context) {
+                                              return InputDialog(vm.username,
+                                                  (input) {
+                                                vm.setUsername(input);
+                                              });
+                                            },
+                                          ),
+                                        ),
+                                      ),
                                     ),
-                                  ),
+                                    Consumer<MainViewModel>(
+                                      builder: (context, viewModel, child) =>
+                                          Text(
+                                        viewModel.username,
+                                        textAlign: TextAlign.start,
+                                        maxLines: 1,
+                                        overflow: TextOverflow.clip,
+                                        style: const TextStyle(
+                                          fontWeight: FontWeight.w700,
+                                          fontStyle: FontStyle.normal,
+                                          fontSize: 18,
+                                          color: Color(0xff000000),
+                                        ),
+                                      ),
+                                    ),
+                                  ],
                                 ),
                                 const Padding(
                                     padding: EdgeInsets.fromLTRB(0, 4, 0, 0),
@@ -112,46 +145,55 @@ class MainScreen extends StatelessWidget {
                       ],
                     ),
                   ),
-                  Padding(
-                    padding:
-                        const EdgeInsets.symmetric(vertical: 0, horizontal: 30),
-                    child: MaterialButton(
-                      color: const Color(0x343a57e8),
-                      elevation: 0,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12.0),
-                      ),
-                      padding: const EdgeInsets.all(16),
-                      textColor: const Color(0xff3a57e8),
-                      minWidth: MediaQuery.of(context).size.width,
-                      child: const Text(
-                        "Change Username",
-                        style: TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w700,
-                          fontStyle: FontStyle.normal,
-                        ),
-                      ),
-                      onPressed: () => showDialog(
-                        context: context,
-                        builder: (context) {
-                          return InputDialog(vm.username, (input) {
-                            vm.setUsername(input);
-                          });
-                        },
-                      ),
-                    ),
-                  ),
+                  Consumer<MainViewModel>(
+                      builder: (context, viewModel, child) => ListView(
+                            scrollDirection: Axis.vertical,
+                            padding: const EdgeInsets.symmetric(horizontal: 16),
+                            shrinkWrap: true,
+                            physics: const ScrollPhysics(),
+                            children: [
+                              ListTile(
+                                title: const Text("Strategy"),
+                                trailing: DropdownButton<NearbyStrategies>(
+                                  value: viewModel.strategy,
+                                  elevation: 16,
+                                  style: TextStyle(
+                                      color: viewModel.advertiserMode
+                                          ? Colors.blue
+                                          : Colors.red),
+                                  underline: Container(
+                                    height: 2,
+                                    color: viewModel.advertiserMode
+                                        ? Colors.blue
+                                        : Colors.red,
+                                  ),
+                                  onChanged: (NearbyStrategies? value) {
+                                    viewModel.setStrategy(value!);
+                                  },
+                                  items: NearbyStrategies.values
+                                      .map<DropdownMenuItem<NearbyStrategies>>(
+                                          (NearbyStrategies value) {
+                                    return DropdownMenuItem<NearbyStrategies>(
+                                      value: value,
+                                      child: Text(value.toPresentationString()),
+                                    );
+                                  }).toList(),
+                                ),
+                              )
+                            ],
+                          )),
                   Consumer<MainViewModel>(
                     builder: (context, viewModel, child) =>
                         viewModel.advertiserMode
                             ? Consumer<MainViewModel>(
                                 builder: (context, viewModel, child) =>
-                                    AdvertiserActions(viewModel.username),
+                                    AdvertiserActions(
+                                        viewModel.username, viewModel.strategy),
                               )
                             : Consumer<MainViewModel>(
                                 builder: (context, viewModel, child) =>
-                                    DiscovererActions(viewModel.username),
+                                    DiscovererActions(
+                                        viewModel.username, viewModel.strategy),
                               ),
                   )
                 ],

--- a/example/lib/viewmodels/advertiser_viewmodel.dart
+++ b/example/lib/viewmodels/advertiser_viewmodel.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
+import 'package:nearby_cross/constants/nearby_strategies.dart';
 import 'package:nearby_cross/models/connections_manager_model.dart';
 import 'package:nearby_cross/models/device_model.dart';
 import 'package:nearby_cross/models/advertiser_model.dart';
@@ -55,11 +56,11 @@ class AdvertiserViewModel with ChangeNotifier {
   bool get isAdvertising => advertiser.isAdvertising;
   bool get manualAcceptConnections => _manualAcceptConnections;
 
-  Future<void> startAdvertising() async {
+  Future<void> startAdvertising(NearbyStrategies strategy) async {
     await advertiser
         .requestPermissions(); // TODO: move this to the constructor of the plugin
     await advertiser.advertise(_username,
-        manualAcceptConnections: _manualAcceptConnections);
+        manualAcceptConnections: _manualAcceptConnections, strategy: strategy);
     notifyListeners();
   }
 

--- a/example/lib/viewmodels/discoverer_viewmodel.dart
+++ b/example/lib/viewmodels/discoverer_viewmodel.dart
@@ -2,6 +2,7 @@ import 'dart:collection';
 
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
+import 'package:nearby_cross/constants/nearby_strategies.dart';
 import 'package:nearby_cross/models/connections_manager_model.dart';
 import 'package:nearby_cross/models/device_model.dart';
 import 'package:nearby_cross/models/discoverer_model.dart';
@@ -20,8 +21,8 @@ class DiscovererViewModel with ChangeNotifier {
     _username = discoverer.username;
 
     connectionsManager = ConnectionsManager();
-    connectionsManager.setCallbackPendingAcceptConnection(
-        _setCallbackPendingAcceptConnection);
+    connectionsManager
+        .setCallbackPendingAcceptConnection(_callbackPendingAcceptConnection);
     connectionsManager.setCallbackConnectionInitiated(_commonCallback);
     connectionsManager
         .setCallbackSuccessfulConnection(_callbackSuccessfulConnection);
@@ -31,8 +32,9 @@ class DiscovererViewModel with ChangeNotifier {
     notifyListeners();
   }
 
-  void _setCallbackPendingAcceptConnection(Device device) {
+  void _callbackPendingAcceptConnection(Device device) {
     Logger().i("Device ${device.endpointName} wants to connect");
+    _commonCallback(device);
   }
 
   void _callbackSuccessfulConnection(Device device) {
@@ -64,10 +66,10 @@ class DiscovererViewModel with ChangeNotifier {
     return _username != null;
   }
 
-  Future<void> startDiscovering() async {
+  Future<void> startDiscovering(NearbyStrategies strategy) async {
     await discoverer
         .requestPermissions(); // TODO: move this to the constructor of the plugin
-    await discoverer.startDiscovery(_username);
+    await discoverer.startDiscovery(_username, strategy: strategy);
     notifyListeners();
   }
 

--- a/example/lib/viewmodels/main_viewmodel.dart
+++ b/example/lib/viewmodels/main_viewmodel.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:nearby_cross/constants/nearby_strategies.dart';
 
 class MainViewModel with ChangeNotifier {
   String? _username;
   bool advertiserMode = true;
   String get mode => advertiserMode ? "Advertiser" : "Discoverer";
+  NearbyStrategies strategy = NearbyStrategies.star;
 
   MainViewModel();
 
@@ -14,6 +16,11 @@ class MainViewModel with ChangeNotifier {
 
   void setUsername(String username) {
     _username = username;
+    notifyListeners();
+  }
+
+  void setStrategy(NearbyStrategies strategy) {
+    this.strategy = strategy;
     notifyListeners();
   }
 

--- a/example/lib/widgets/advertiser_actions.dart
+++ b/example/lib/widgets/advertiser_actions.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:nearby_cross/constants/nearby_strategies.dart';
 import 'package:nearby_cross_example/screens/pending_connections_list.dart';
 import 'package:nearby_cross_example/viewmodels/advertiser_viewmodel.dart';
 import 'package:provider/provider.dart';
@@ -7,7 +8,8 @@ import '../screens/advertiser_comunication_screen.dart';
 
 class AdvertiserActions extends StatelessWidget {
   final String? username;
-  const AdvertiserActions(this.username, {super.key});
+  final NearbyStrategies? strategy;
+  const AdvertiserActions(this.username, this.strategy, {super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -54,7 +56,7 @@ class AdvertiserActions extends StatelessWidget {
                   ),
                   onChanged: (value) => value == false
                       ? app.stopAdvertising()
-                      : app.startAdvertising(),
+                      : app.startAdvertising(strategy!),
                 ),
               ),
               const Divider(

--- a/example/lib/widgets/discoverer_actions.dart
+++ b/example/lib/widgets/discoverer_actions.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:nearby_cross/constants/nearby_strategies.dart';
 import 'package:nearby_cross_example/viewmodels/discoverer_viewmodel.dart';
 import 'package:provider/provider.dart';
 
@@ -7,7 +8,8 @@ import '../screens/discoverer_comunication_screen.dart';
 
 class DiscovererActions extends StatelessWidget {
   final String? username;
-  const DiscovererActions(this.username, {super.key});
+  final NearbyStrategies? strategy;
+  const DiscovererActions(this.username, this.strategy, {super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -41,7 +43,7 @@ class DiscovererActions extends StatelessWidget {
                     onChanged: (value) => {
                       !value
                           ? viewModel.stopDiscovery()
-                          : viewModel.startDiscovering()
+                          : viewModel.startDiscovering(strategy!)
                     },
                   ),
                 ),

--- a/lib/constants/nearby_strategies.dart
+++ b/lib/constants/nearby_strategies.dart
@@ -1,0 +1,25 @@
+enum NearbyStrategies { cluster, star, pointToPoint }
+
+extension NearbyStrategiesString on NearbyStrategies {
+  String toPresentationString() {
+    switch (this) {
+      case NearbyStrategies.cluster:
+        return "Cluster";
+      case NearbyStrategies.star:
+        return "Star";
+      case NearbyStrategies.pointToPoint:
+        return "Point to Point";
+    }
+  }
+
+  String toStrategyString() {
+    switch (this) {
+      case NearbyStrategies.cluster:
+        return "P2P_CLUSTER";
+      case NearbyStrategies.star:
+        return "P2P_STAR";
+      case NearbyStrategies.pointToPoint:
+        return "P2P_POINT_TO_POINT";
+    }
+  }
+}

--- a/lib/models/advertiser_model.dart
+++ b/lib/models/advertiser_model.dart
@@ -1,3 +1,4 @@
+import 'package:nearby_cross/constants/nearby_strategies.dart';
 import 'package:nearby_cross/models/connector_model.dart';
 
 /// Class that represent the Advertiser instance of NearbyCross plugin.
@@ -14,8 +15,10 @@ class Advertiser extends Connector {
 
   /// Service to start advertising using NearbyCross plugin
   Future<void> advertise(String? username,
-      {bool manualAcceptConnections = false}) async {
-    await nearbyCross.advertise(serviceId, username, manualAcceptConnections);
+      {bool manualAcceptConnections = false,
+      NearbyStrategies strategy = NearbyStrategies.star}) async {
+    await nearbyCross.advertise(
+        serviceId, username, manualAcceptConnections, strategy);
     isAdvertising = true;
     this.username = username;
   }

--- a/lib/models/discoverer_model.dart
+++ b/lib/models/discoverer_model.dart
@@ -1,3 +1,4 @@
+import 'package:nearby_cross/constants/nearby_strategies.dart';
 import 'package:nearby_cross/models/connector_model.dart';
 import 'package:nearby_cross/models/device_model.dart';
 import 'package:nearby_cross/nearby_cross_methods.dart';
@@ -31,9 +32,10 @@ class Discoverer extends Connector {
   }
 
   /// Service to start discovering devices using NearbyCross plugin
-  Future<void> startDiscovery(String? username) async {
+  Future<void> startDiscovery(String? username,
+      {NearbyStrategies strategy = NearbyStrategies.star}) async {
     listOfDiscoveredDevices.clear();
-    await nearbyCross.startDiscovery(serviceId, username);
+    await nearbyCross.startDiscovery(serviceId, username, strategy);
     isDiscovering = true;
     this.username = username;
   }

--- a/lib/nearby_cross.dart
+++ b/lib/nearby_cross.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:logger/logger.dart';
+import 'package:nearby_cross/constants/nearby_strategies.dart';
 import 'package:nearby_cross/helpers/permission_manager.dart';
 import 'package:nearby_cross/nearby_cross_methods.dart';
 
@@ -45,20 +46,22 @@ class NearbyCross {
     return version;
   }
 
-  Future<void> startDiscovery(String serviceId, String? username) async {
+  Future<void> startDiscovery(String serviceId, String? username,
+      [NearbyStrategies strategy = NearbyStrategies.star]) async {
     await methodChannel.invokeMethod('startDiscovery', {
       'serviceId': serviceId,
       'username': username ?? 'generic_discoverer_name',
-      'strategy': 'P2P_STAR'
+      'strategy': strategy.toStrategyString()
     });
   }
 
   Future<void> advertise(
-      String serviceId, String? username, bool manualAcceptConnections) async {
+      String serviceId, String? username, bool manualAcceptConnections,
+      [NearbyStrategies strategy = NearbyStrategies.star]) async {
     await methodChannel.invokeMethod('startAdvertising', {
       'serviceId': serviceId,
       'username': username ?? 'generic_advertiser_name',
-      'strategy': 'P2P_STAR',
+      'strategy': strategy.toStrategyString(),
       'manualAcceptConnections': manualAcceptConnections ? "1" : "0"
     });
   }


### PR DESCRIPTION
## Main changes

- Allow app users to configure strategy (one of POINT_TO_POINT, STAR or CLUSTER)
    - Only devices that are advertising with the same strategy as every available discoverer will be visible

<img width="493" alt="Captura de pantalla 2024-02-19 a la(s) 22 02 16" src="https://github.com/IgVelasco/nearby_cross/assets/33533052/3bda0527-0031-45f7-99a1-b8b4d69a5f06">
<img width="493" alt="Captura de pantalla 2024-02-19 a la(s) 22 02 20" src="https://github.com/IgVelasco/nearby_cross/assets/33533052/981b6e86-8461-4bd8-8e1e-bed4edde96f4">
