### PR TITLE
NearbyMessageType to Class type

### DIFF
--- a/example/lib/models/chat_message.dart
+++ b/example/lib/models/chat_message.dart
@@ -25,7 +25,7 @@ class ChatMessage extends NearbyMessage {
     var inputFormat = DateFormat('dd/MM/yyyy HH:mm');
     var authBadge = isAuthenticated ? '✅' : '❌';
     if (printSender && sender != null) {
-      return "${received ? authBadge : ''} ${(sender)} ${inputFormat.format(dateTime)} - ${BytesUtils.getString(message)}";
+      return "${received ? authBadge : ''} ${BytesUtils.getString(sender!)} ${inputFormat.format(dateTime)} - ${BytesUtils.getString(message)}";
     }
 
     return "${received ? authBadge : ''} ${inputFormat.format(dateTime)} - ${BytesUtils.getString(message)}";

--- a/example/lib/viewmodels/broadcast_viewmodel.dart
+++ b/example/lib/viewmodels/broadcast_viewmodel.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
 import 'package:nearby_cross/models/connections_manager_model.dart';
@@ -28,10 +31,20 @@ class BroadcastViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  Uint8List getEndpointNameFromDevice(Device device) {
+    var fullDeviceInfo = device.endpointName;
+    var indexSeparator = fullDeviceInfo.indexOf(utf8.encode("&")[0]);
+    if (indexSeparator == -1) {
+      return fullDeviceInfo;
+    }
+    var deviceName = fullDeviceInfo.sublist(0, indexSeparator);
+    return deviceName;
+  }
+
   void _callbackReceivedMessage(Device device) {
     var message = ChatMessage.fromParent(device.getLastMessage()!,
         received: true,
-        sender: device.endpointName,
+        sender: getEndpointNameFromDevice(device),
         isAuthenticated: device.lastMassageIsAuthenticated());
     allMessages.add(message);
     _commonCallback(device);

--- a/lib/models/message_model.dart
+++ b/lib/models/message_model.dart
@@ -4,10 +4,14 @@ import 'dart:typed_data';
 import 'package:nearby_cross/helpers/bytes_utils.dart';
 import 'package:nearby_cross/modules/authentication/signing_manager.dart';
 
-enum NearbyMessageType {
-  direct,
-  broadcast,
-  handshake;
+class NearbyMessageType {
+  static const NearbyMessageType direct = NearbyMessageType._(0);
+  static const NearbyMessageType broadcast = NearbyMessageType._(1);
+  static const NearbyMessageType handshake = NearbyMessageType._(2);
+
+  final int type;
+
+  const NearbyMessageType._(this.type);
 
   static fromInt8(int value) {
     switch (value) {
@@ -21,22 +25,11 @@ enum NearbyMessageType {
         throw UnimplementedError();
     }
   }
-}
 
-extension NearbyMessageTypeInt on NearbyMessageType {
   Uint8List toInt8() {
     var aux = Uint8List(1)..buffer.asInt8List();
-    switch (this) {
-      case NearbyMessageType.direct:
-        aux[0] = 0;
-        return aux;
-      case NearbyMessageType.broadcast:
-        aux[0] = 1;
-        return aux;
-      case NearbyMessageType.handshake:
-        aux[0] = 2;
-        return aux;
-    }
+    aux[0] = type;
+    return aux;
   }
 }
 


### PR DESCRIPTION
## Main Description

- Converts the `NearbyMessageType` enum to a `NearbyMessageType` class. This will allow the consumers of this plugin to extend the class functionality to adapt it to their use cases (changes in lib/models/message_model.dart)
- (MINOR) Fixes a bug in Broadcast screen, where the device name was not being parsed correctly
