### PR TITLE
Fix: Replace "&" separator character with RS byte (0x1E)

### DIFF
--- a/example/lib/constants/app.constants.dart
+++ b/example/lib/constants/app.constants.dart
@@ -1,0 +1,4 @@
+class AppConstants {
+  static const int separatorByte = 0x1E;
+  static const List<int> separator = [separatorByte];
+}

--- a/example/lib/viewmodels/advertiser_viewmodel.dart
+++ b/example/lib/viewmodels/advertiser_viewmodel.dart
@@ -8,6 +8,7 @@ import 'package:nearby_cross/helpers/platform_utils.dart';
 import 'package:nearby_cross/models/connections_manager_model.dart';
 import 'package:nearby_cross/models/device_model.dart';
 import 'package:nearby_cross/models/advertiser_model.dart';
+import 'package:nearby_cross_example/constants/app.constants.dart';
 
 class AdvertiserViewModel with ChangeNotifier {
   late Advertiser advertiser;
@@ -66,7 +67,7 @@ class AdvertiserViewModel with ChangeNotifier {
     if (signingManger != null) {
       var deviceInfoSign = signingManger.getSignatureBytes(deviceInfo);
 
-      bb.add(utf8.encode("&"));
+      bb.add(AppConstants.separator);
       bb.add(deviceInfoSign);
     }
 

--- a/example/lib/viewmodels/broadcast_viewmodel.dart
+++ b/example/lib/viewmodels/broadcast_viewmodel.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -6,6 +5,7 @@ import 'package:logger/logger.dart';
 import 'package:nearby_cross/models/connections_manager_model.dart';
 import 'package:nearby_cross/models/device_model.dart';
 import 'package:nearby_cross/models/message_model.dart';
+import 'package:nearby_cross_example/constants/app.constants.dart';
 import 'package:nearby_cross_example/models/chat_message.dart';
 
 class BroadcastViewModel extends ChangeNotifier {
@@ -33,7 +33,7 @@ class BroadcastViewModel extends ChangeNotifier {
 
   Uint8List getEndpointNameFromDevice(Device device) {
     var fullDeviceInfo = device.endpointName;
-    var indexSeparator = fullDeviceInfo.indexOf(utf8.encode("&")[0]);
+    var indexSeparator = fullDeviceInfo.indexOf(AppConstants.separatorByte);
     if (indexSeparator == -1) {
       return fullDeviceInfo;
     }

--- a/example/lib/viewmodels/discoverer_viewmodel.dart
+++ b/example/lib/viewmodels/discoverer_viewmodel.dart
@@ -8,6 +8,7 @@ import 'package:nearby_cross/helpers/platform_utils.dart';
 import 'package:nearby_cross/models/connections_manager_model.dart';
 import 'package:nearby_cross/models/device_model.dart';
 import 'package:nearby_cross/models/discoverer_model.dart';
+import 'package:nearby_cross_example/constants/app.constants.dart';
 
 class DiscovererViewModel with ChangeNotifier {
   late Discoverer discoverer;
@@ -126,7 +127,7 @@ class DiscovererViewModel with ChangeNotifier {
     if (signingManger != null) {
       var deviceInfoSign = signingManger.getSignatureBytes(deviceInfo);
 
-      bb.add(utf8.encode("&"));
+      bb.add(AppConstants.separator);
       bb.add(deviceInfoSign);
     }
 
@@ -174,7 +175,7 @@ class DiscovererViewModel with ChangeNotifier {
 
   String getEndpointNameFromDevice(Device device) {
     var fullDeviceInfo = device.endpointName;
-    var indexSeparator = fullDeviceInfo.indexOf(utf8.encode("&")[0]);
+    var indexSeparator = fullDeviceInfo.indexOf(AppConstants.separatorByte);
     if (indexSeparator == -1) {
       return utf8.decode(fullDeviceInfo);
     }
@@ -184,7 +185,7 @@ class DiscovererViewModel with ChangeNotifier {
 
   int getSignatureBytes(Device device) {
     var fullDeviceInfo = device.endpointName;
-    var indexSeparator = fullDeviceInfo.indexOf(utf8.encode("&")[0]);
+    var indexSeparator = fullDeviceInfo.indexOf(AppConstants.separatorByte);
     if (indexSeparator == -1) {
       return 0;
     }

--- a/example/lib/viewmodels/pending_connections_viewmodel.dart
+++ b/example/lib/viewmodels/pending_connections_viewmodel.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
 import 'package:nearby_cross/models/connections_manager_model.dart';
 import 'package:nearby_cross/models/device_model.dart';
+import 'package:nearby_cross_example/constants/app.constants.dart';
 
 class PendingConnectionsViewModel with ChangeNotifier {
   Logger logger = Logger();
@@ -72,7 +73,7 @@ class PendingConnectionsViewModel with ChangeNotifier {
 
   String getEndpointNameFromDevice(Device device) {
     var fullDeviceInfo = device.endpointName;
-    var indexSeparator = fullDeviceInfo.indexOf(utf8.encode("&")[0]);
+    var indexSeparator = fullDeviceInfo.indexOf(AppConstants.separatorByte);
     if (indexSeparator == -1) {
       return utf8.decode(fullDeviceInfo);
     }

--- a/example/lib/viewmodels/select_interaction_viewmodel.dart
+++ b/example/lib/viewmodels/select_interaction_viewmodel.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
 import 'package:nearby_cross/models/connections_manager_model.dart';
 import 'package:nearby_cross/models/device_model.dart';
+import 'package:nearby_cross_example/constants/app.constants.dart';
 
 class SelectInteractionViewModel with ChangeNotifier {
   Logger logger = Logger();
@@ -74,7 +75,7 @@ class SelectInteractionViewModel with ChangeNotifier {
 
   String getEndpointNameFromDevice(Device device) {
     var fullDeviceInfo = device.endpointName;
-    var indexSeparator = fullDeviceInfo.indexOf(utf8.encode("&")[0]);
+    var indexSeparator = fullDeviceInfo.indexOf(AppConstants.separatorByte);
     if (indexSeparator == -1) {
       return utf8.decode(fullDeviceInfo);
     }

--- a/lib/models/message_model.dart
+++ b/lib/models/message_model.dart
@@ -45,15 +45,21 @@ class NearbyMessageType {
 
 /*
 * Converted:
-* - messageType (1 int 8bit) + dateTime (1 int 64bit) + payloadSize (1 int 64bit) (N) + payload (N int 8bit) + signature (M int 64bit)
+* - messageType (1 int 8bit) + dateTime (1 int 64bit) + payloadSize (1 int 64bit) (N) + payload (N int 8bit) + signature (64 bytes)
 */
 class NearbyMessage {
-  late NearbyMessageType messageType; // 0 direct, 1 broadcast
+  late NearbyMessageType messageType;
   late DateTime dateTime;
   late int pSize;
   late Uint8List message;
   late Uint8List signature;
   bool isAuthenticated = false;
+
+  NearbyMessage.fromBytes(this.message,
+      {this.messageType = NearbyMessageType.direct, signature})
+      : dateTime = DateTime.now(),
+        pSize = message.length,
+        signature = signature ?? Uint8List(0);
 
   NearbyMessage.fromString(String message,
       {this.messageType = NearbyMessageType.direct, signature})


### PR DESCRIPTION
## Main changes
- Adds a new constructor to NearbyMessage that allows to construct a message having a byte-encoded message rather than a string message
- Replaces the use of "&" (which is a valid UTF8 encodable character) with the use of byte 0x1E [(Record separator or RS)](https://en.wikipedia.org/wiki/Delimiter) which follows ASCII conventions for delimeters